### PR TITLE
Update MVP.rexx to sort the list of installed pkgs

### DIFF
--- a/MVP.rexx
+++ b/MVP.rexx
@@ -116,10 +116,20 @@ SELECT
   WHEN UPPER(ACTION) == "LIST" THEN
     DO
       IF UPPER(PACKAGE) = '--INSTALLED' THEN DO
+ 
+        DO I=1 TO MVPDB.0
+          SORTIN.I = MVPDB.I
+        END 
+        
+        SORTIN.0 = MVPDB.0
+
+        CALL DEBUG "SORTING CACHE BEFORE PRINTING"
+        CALL RXSORT
+ 
         SAY "LISTING INSTALLED PACKAGES:"
         SAY ""
-        DO I=1 TO MVPDB.0
-          SAY "" MVPDB.I
+        DO I=1 TO SORTIN.0
+          SAY "" SORTIN.I
         END
       END
       ELSE IF LENGTH(PACKAGE) > 0 THEN DO


### PR DESCRIPTION
Closes #6 

The attached pull request changes the behavior of `rx mvp list --installed` to sort the list before printing it to the terminal.  This results in behavior that is consistent to that of the `rx mvp list` command.

Example of the new sorted output follows:

```
 READY                       
rx mvp list --installed      
 LISTING INSTALLED PACKAGES: 
                             
  CCOMPR 0.9                 
  CHKDSN 1.0                 
  COMPARE 1.11               
  CUTIL00 1.1.5              
  DALCDS 1.0                 
  DFSPC 1.0                  
  DUCBD 1.0                  
  FINDSRCH 0.9.11            
  GETDTE 1.0                 
  IND$FILE 2.0.5             
  ISPF 2.2.0                 
  ISPOPT5 0.9                
  ISPTHEME 1.0               
  LISTDSJ 2.0                
  MACLIB 1.0                 
  PRINTOFF 1.0               
  PUTCARD 1.0                
  REVIEW 50.1                
  ULXL01 1.1                 
  VTOC 1.0                   
  WRLDWTCH 0.9               
                             
 LISTING DONE                
 READY                       
```